### PR TITLE
fix: platform to locker exception bug

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -61,7 +61,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.1.1"
+    version: "2.1.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/lib/src/flutter_locker.dart
+++ b/lib/src/flutter_locker.dart
@@ -43,7 +43,7 @@ class FlutterLocker {
     try {
       return await function();
     } on PlatformException catch (exception) {
-      final lockerException = LockerException.fromCode(exception.message);
+      final lockerException = LockerException.fromCode(exception.code);
       // ignore: avoid_print
       print('Locker exception: [${exception.message}] $lockerException');
       if (lockerException != null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_locker
 description: Secures your secrets in keychain using biometric authentication (Fingerprint, Touch ID, Face ID...)
-version: 2.1.1
+version: 2.1.2
 repository: https://github.com/infinum/flutter-plugins-locker
 homepage: https://github.com/infinum/flutter-plugins-locker
 


### PR DESCRIPTION
Right now the exception handling doesn't work properly: the library throws PlatformException instead of LockerException instances. That's caused by the use of the PlatformException's message property instead of the code property.

This PR fixes uses the exception code instead of the message and fixes the issue.