### PR TITLE
fix creation of locker exception

### DIFF
--- a/lib/src/flutter_locker.dart
+++ b/lib/src/flutter_locker.dart
@@ -43,7 +43,7 @@ class FlutterLocker {
     try {
       return await function();
     } on PlatformException catch (exception) {
-      final lockerException = LockerException.fromCode(exception.code);
+      final lockerException = LockerException.fromCode(exception.message);
       // ignore: avoid_print
       print('Locker exception: [${exception.message}] $lockerException');
       if (lockerException != null) {


### PR DESCRIPTION
This pull request regards the [Issue 35](https://github.com/infinum/flutter-plugins-locker/issues/35)

The exception.code always contains the string "LockerException". The needed code probably is found in exception.message (which seems odd).

I tested it in my app and the LockerException is created correctly. 